### PR TITLE
fix(proxy): resolve bare STRM URLs before Emby fallback

### DIFF
--- a/apps/backend/src/routes/proxy/bare-strm-match.ts
+++ b/apps/backend/src/routes/proxy/bare-strm-match.ts
@@ -1,0 +1,78 @@
+import type { TaskDefinition } from "@openstrm/shared";
+import { safeDecode } from "../../services/strm/naming.js";
+
+export interface BareStrmMatch {
+  task: TaskDefinition;
+  /** Reconstructed URL in the same shape as the URL stored in the .strm file. */
+  embyPath: string;
+}
+
+function normalizePath(input: string): string {
+  const decoded = safeDecode(input || "/");
+  const withLeadingSlash = decoded.startsWith("/") ? decoded : `/${decoded}`;
+  const collapsed = withLeadingSlash.replace(/\/{2,}/g, "/");
+  if (collapsed === "/") return collapsed;
+  return collapsed.replace(/\/+$/, "");
+}
+
+function originPathOf(task: TaskDefinition): string {
+  return normalizePath(`/${task.originPath ?? ""}`);
+}
+
+function parsePrefix(task: TaskDefinition): URL | null {
+  if (!task.enable302 || !task.strmPrefix) return null;
+
+  try {
+    const prefix = new URL(task.strmPrefix);
+    if (prefix.protocol !== "http:" && prefix.protocol !== "https:") return null;
+    if (prefix.search || prefix.hash) return null;
+    prefix.pathname = normalizePath(prefix.pathname);
+    return prefix;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the task which owns a direct request for a URL written by OpenStrm.
+ *
+ * The request only contains a path, while the task stores the full strmPrefix.
+ * Reconstructing the full URL here lets the existing resolver reuse its normal
+ * task/account matching rules without exposing arbitrary paths below a prefix.
+ */
+export function matchBareStrmRequest(
+  pathname: string,
+  host: string | undefined,
+  tasks: TaskDefinition[],
+): BareStrmMatch | null {
+  const requestPath = normalizePath(pathname);
+  const requestHost = host?.toLowerCase();
+  const matches: Array<{ task: TaskDefinition; embyPath: string; originLength: number; prefixLength: number }> = [];
+
+  for (const task of tasks) {
+    const prefix = parsePrefix(task);
+    if (!prefix) continue;
+    if (requestHost && prefix.host.toLowerCase() !== requestHost) continue;
+
+    const prefixPath = normalizePath(prefix.pathname);
+    const prefixMatches =
+      prefixPath === "/" || requestPath === prefixPath || requestPath.startsWith(`${prefixPath}/`);
+    if (!prefixMatches) continue;
+
+    const rest = prefixPath === "/" ? requestPath : requestPath.slice(prefixPath.length) || "/";
+    const origin = originPathOf(task);
+    const withinOrigin = origin === "/" || rest === origin || rest.startsWith(`${origin}/`);
+    if (!withinOrigin || rest === origin) continue;
+
+    matches.push({
+      task,
+      embyPath: `${prefix.origin}${requestPath}`,
+      originLength: origin.length,
+      prefixLength: prefixPath.length,
+    });
+  }
+
+  matches.sort((a, b) => b.originLength - a.originLength || b.prefixLength - a.prefixLength);
+  const best = matches[0];
+  return best ? { task: best.task, embyPath: best.embyPath } : null;
+}

--- a/apps/backend/src/routes/proxy/bare-strm.test.ts
+++ b/apps/backend/src/routes/proxy/bare-strm.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { TaskDefinition } from "@openstrm/shared";
+import { matchBareStrmRequest } from "./bare-strm-match.js";
+
+const task: TaskDefinition = {
+  id: "task-main",
+  account: "main",
+  accountType: "115",
+  originPath: "library",
+  targetPath: "strm/library",
+  strmPrefix: "http://media.example:8098/main",
+  enable302: true,
+};
+
+test("matches a direct request made from a configured HTTP STRM prefix", () => {
+  const match = matchBareStrmRequest(
+    "/main/library/movie.mkv",
+    "media.example:8098",
+    [task],
+  );
+
+  assert.equal(match?.task.id, "task-main");
+  assert.equal(match?.embyPath, "http://media.example:8098/main/library/movie.mkv");
+});
+
+test("does not match another host, a path outside the task origin, or a disabled task", () => {
+  assert.equal(
+    matchBareStrmRequest("/main/library/movie.mkv", "other.example:8098", [task]),
+    null,
+  );
+  assert.equal(
+    matchBareStrmRequest("/main/private/movie.mkv", "media.example:8098", [task]),
+    null,
+  );
+  assert.equal(
+    matchBareStrmRequest(
+      "/main/library/movie.mkv",
+      "media.example:8098",
+      [{ ...task, enable302: false }],
+    ),
+    null,
+  );
+});
+
+test("prefers the most specific origin path when tasks share a prefix", () => {
+  const child = { ...task, id: "task-child", originPath: "library/anime" };
+  const match = matchBareStrmRequest(
+    "/main/library/anime/episode.mkv",
+    "media.example:8098",
+    [task, child],
+  );
+
+  assert.equal(match?.task.id, "task-child");
+});
+
+test("matches a prefix whose URL has no path component", () => {
+  const rootPrefixTask = { ...task, id: "task-root", strmPrefix: "http://media.example:8098" };
+  const match = matchBareStrmRequest(
+    "/library/movie.mkv",
+    "media.example:8098",
+    [rootPrefixTask],
+  );
+
+  assert.equal(match?.task.id, "task-root");
+  assert.equal(match?.embyPath, "http://media.example:8098/library/movie.mkv");
+});

--- a/apps/backend/src/routes/proxy/bare-strm.ts
+++ b/apps/backend/src/routes/proxy/bare-strm.ts
@@ -1,0 +1,38 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { listTasks } from "../../db/repositories/tasks.js";
+import { matchBareStrmRequest } from "./bare-strm-match.js";
+import { redirectBareStrm } from "./redirect.js";
+
+export { matchBareStrmRequest } from "./bare-strm-match.js";
+
+function requestPath(request: FastifyRequest): string {
+  return new URL(request.url, "http://openstrm.local").pathname;
+}
+
+/**
+ * Handle a direct request to the URL written inside a generated .strm file.
+ *
+ * Returning false is intentional: the catch-all proxy must keep its original
+ * fallback behavior when the request is not one of our configured STRMs or
+ * when link resolution fails.
+ */
+export async function handleBareStrm(request: FastifyRequest, reply: FastifyReply): Promise<boolean> {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+
+  let tasks;
+  try {
+    tasks = listTasks();
+  } catch {
+    return false;
+  }
+
+  const match = matchBareStrmRequest(requestPath(request), request.headers.host, tasks);
+  if (!match) return false;
+
+  return redirectBareStrm(
+    request,
+    reply,
+    match.embyPath,
+    `task:${match.task.id}:${match.embyPath}`,
+  );
+}

--- a/apps/backend/src/routes/proxy/catch-all.ts
+++ b/apps/backend/src/routes/proxy/catch-all.ts
@@ -2,11 +2,18 @@ import type { FastifyInstance } from "fastify";
 import httpProxy from "@fastify/http-proxy";
 import { embyUpstream } from "../../services/emby/api.js";
 import { applyForwardedHeaders } from "./upstream.js";
+import { handleBareStrm } from "./bare-strm.js";
 
 /**
  * 兜底反代到 Emby。必须最后注册，让拦截路由优先。
  */
 export default async function catchAllProxy(fastify: FastifyInstance) {
+  // @fastify/http-proxy 自己注册 /*，不能再注册一个同样的通配路由。
+  // 在父作用域挂 preHandler，确保它也作用于下面的 proxy 子插件路由。
+  fastify.addHook("preHandler", async (request, reply) => {
+    if (await handleBareStrm(request, reply)) return reply;
+  });
+
   await fastify.register(httpProxy, {
     /**
      * 故意不填 upstream，全部交给 getUpstream 每请求现读。

--- a/apps/backend/src/routes/proxy/proxy.itest.ts
+++ b/apps/backend/src/routes/proxy/proxy.itest.ts
@@ -30,6 +30,9 @@ const LOCAL_FILE = "/media/local/movie.mkv";
 /** strm 里写 OpenList 地址的那种任务：前缀是 URL，代理按 URL 匹配挂载点 */
 const HTTP_MOUNT = "http://ol.local:5244/d/115";
 const HTTP_FILE = `${HTTP_MOUNT}/tv/Show/ep1.mkv`;
+/** 生成的裸 STRM URL：host/path 必须作为任务边界参与匹配 */
+const BARE_STRM_HOST = "strm.local:8098";
+const BARE_STRM_PREFIX = `http://${BARE_STRM_HOST}/main`;
 /**
  * 真实形态的 115 直链：文件名已经是转义过的，签名里带 `+` 和 `=`。
  * 必须**原样**出现在 Location 里：再做一次 encodeURI 的话
@@ -39,6 +42,30 @@ const DIRECT_URL =
   "https://cdn-qn.115.com/lab/%E4%B8%AD%E6%96%87%E5%90%8D.mkv?t=1&u=a%2Bb&sign=xY%3D%3D";
 /** 混进非 ASCII 的异常直链，只有这种才需要转义 */
 const UNICODE_URL = "https://cdn.115.com/直链?t=1";
+
+const MEDIA_BYTES = Buffer.from("0123456789abcdef");
+const media = http.createServer((request, response) => {
+  if (request.headers.range === "bytes=0-3") {
+    const body = MEDIA_BYTES.subarray(0, 4);
+    response.writeHead(206, {
+      "accept-ranges": "bytes",
+      "content-length": body.length,
+      "content-range": `bytes 0-3/${MEDIA_BYTES.length}`,
+      "content-type": "video/x-matroska",
+    });
+    response.end(body);
+    return;
+  }
+  response.writeHead(200, {
+    "accept-ranges": "bytes",
+    "content-length": MEDIA_BYTES.length,
+    "content-type": "video/x-matroska",
+  });
+  response.end(MEDIA_BYTES);
+});
+await new Promise<void>((resolve) => media.listen(0, "127.0.0.1", resolve));
+const mediaPort = (media.address() as { port: number }).port;
+const MEDIA_URL = `http://127.0.0.1:${mediaPort}/media.mkv`;
 
 // ---- 假 Emby ----
 const emby = http.createServer((req, res) => {
@@ -98,13 +125,21 @@ setSettings({
 const app = Fastify({ logger: false });
 await app.register(proxyPlugin);
 await app.ready();
+insertTask({
+  id: "bare-strm-302",
+  account: "主号",
+  originPath: "library",
+  targetPath: "library",
+  strmPrefix: BARE_STRM_PREFIX,
+  enable302: true,
+});
 
 let resolveCalls = 0;
 let lastResolvedUa: string | undefined;
 setLinkResolver(async (embyPath, userAgent) => {
   resolveCalls++;
   lastResolvedUa = userAgent;
-  return embyPath.startsWith(MOUNT) || embyPath.startsWith(HTTP_MOUNT)
+  return embyPath.startsWith(MOUNT) || embyPath.startsWith(HTTP_MOUNT) || embyPath.startsWith(BARE_STRM_PREFIX)
     ? { ok: true, url: DIRECT_URL, accountName: "主号", panPath: embyPath }
     : { ok: false, reason: "not-mounted" };
 });
@@ -121,6 +156,64 @@ test("挂载点里的条目 302 到直链", async () => {
     const res = await app.inject({ method: "GET", url: "/emby/Videos/item-1/stream.mkv?api_key=k" });
     assert.equal(res.statusCode, 302);
     assert.equal(res.headers.location, DIRECT_URL, "已转义的直链必须原样透传，不能二次编码");
+  });
+
+test("裸 STRM URL 在 catch-all 前被解析并 302，HEAD 复用缓存", async () => {
+    reset();
+    const headers = { host: BARE_STRM_HOST, "user-agent": "Lavf/59.27.100" };
+    const get = await app.inject({ method: "GET", url: "/main/library/movie.mkv", headers });
+    assert.equal(get.statusCode, 302);
+    assert.equal(get.headers.location, DIRECT_URL);
+    assert.equal(resolveCalls, 1, "裸 URL 应调用一次直链解析器");
+
+    const head = await app.inject({ method: "HEAD", url: "/main/library/movie.mkv", headers });
+    assert.equal(head.statusCode, 302);
+    assert.equal(head.headers.location, DIRECT_URL);
+    assert.equal(resolveCalls, 1, "同一裸 URL/UA 的 HEAD 应命中缓存");
+
+    const outsideOrigin = await app.inject({
+      method: "GET",
+      url: "/main/private/movie.mkv",
+      headers,
+    });
+    assert.equal(outsideOrigin.statusCode, 200, "originPath 外的请求必须继续回源 Emby");
+    assert.equal(outsideOrigin.body, "upstream-ok");
+  });
+
+test("裸 STRM 的 302 可跟随到支持 Range 的媒体字节端点", async () => {
+    reset();
+    setLinkResolver(async (embyPath, userAgent) => {
+      resolveCalls++;
+      lastResolvedUa = userAgent;
+      return embyPath.startsWith(BARE_STRM_PREFIX)
+        ? { ok: true, url: MEDIA_URL, accountName: "主号", panPath: embyPath }
+        : { ok: false, reason: "not-mounted" };
+    });
+    try {
+      const redirect = await app.inject({
+        method: "GET",
+        url: "/main/library/movie.mkv",
+        headers: { host: BARE_STRM_HOST, "user-agent": "Lavf/59.27.100", range: "bytes=0-3" },
+      });
+      assert.equal(redirect.statusCode, 302);
+      assert.equal(redirect.headers.location, MEDIA_URL);
+
+      const mediaResponse = await fetch(redirect.headers.location!, {
+        headers: { range: "bytes=0-3" },
+        redirect: "manual",
+      });
+      assert.equal(mediaResponse.status, 206);
+      assert.equal(mediaResponse.headers.get("content-range"), `bytes 0-3/${MEDIA_BYTES.length}`);
+      assert.equal(Buffer.from(await mediaResponse.arrayBuffer()).toString(), "0123");
+    } finally {
+      setLinkResolver(async (embyPath, userAgent) => {
+        resolveCalls++;
+        lastResolvedUa = userAgent;
+        return embyPath.startsWith(MOUNT) || embyPath.startsWith(HTTP_MOUNT) || embyPath.startsWith(BARE_STRM_PREFIX)
+          ? { ok: true, url: DIRECT_URL, accountName: "主号", panPath: embyPath }
+          : { ok: false, reason: "not-mounted" };
+      });
+    }
   });
 
 test("小写路径同样命中（客户端大小写不统一）", async () => {
@@ -609,7 +702,9 @@ test("改配置后旧缓存自动失效（跨进程）", async () => {
   });
 
 after(async () => {
+  deleteTask("bare-strm-302");
   setSettings(baseline);
   await app.close();
   emby.close();
+  media.close();
 });

--- a/apps/backend/src/routes/proxy/redirect.ts
+++ b/apps/backend/src/routes/proxy/redirect.ts
@@ -79,6 +79,46 @@ function safeLocation(url: string): string {
 }
 
 /**
+ * 直接请求 .strm 内容里的 URL 时没有 Emby Item ID，也通常没有 Emby token。
+ *
+ * 这条入口只由 bare-strm.ts 在已匹配任务的前提下调用：strmPrefix 本身就是
+ * 请求能力边界，解析仍复用现有的 115 任务路径解析和直链缓存。返回 false
+ * 表示继续走 catch-all 回源，保持旧的失败兜底语义。
+ */
+export async function redirectBareStrm(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  embyPath: string,
+  cacheScope: string,
+): Promise<boolean> {
+  const userAgent = request.headers["user-agent"];
+  const cacheKey = `${configRevision()}:bare:${cacheScope}:${userAgent ?? ""}`;
+  const cached = linkCache.get(cacheKey);
+  if (cached) {
+    request.log.debug({ scope: cacheScope }, "裸 STRM 302 缓存命中");
+    reply.redirect(cached, 302);
+    return true;
+  }
+
+  try {
+    const resolved = await resolveLink(embyPath, userAgent);
+    if (!resolved.ok) {
+      request.log.debug({ scope: cacheScope, reason: resolved.reason }, "裸 STRM 未解析，回源");
+      return false;
+    }
+
+    const target = safeLocation(resolved.url);
+    linkCache.set(cacheKey, target);
+    request.log.info({ scope: cacheScope, account: resolved.accountName }, "裸 STRM 302 到直链");
+    reply.redirect(target, 302);
+    return true;
+  } catch (err) {
+    request.log.error({ err, scope: cacheScope }, "裸 STRM 解析失败，回源");
+    return false;
+  }
+}
+
+/**
  * 需要"两跳"的客户端。
  *
  * 115 直链和换链时用的 User-Agent 严格绑定（实测：用 A 换的链接拿 B 去取，CDN 直接 403）。


### PR DESCRIPTION
# Upstream PR draft: resolve bare STRM URLs before Emby fallback

## Proposed title

`fix(proxy): resolve bare STRM URLs before Emby fallback`

## Summary

OpenStrm-generated `.strm` files can contain a direct HTTP URL such as:

```text
http://<proxy-host>:<proxy-port>/<configured-prefix>/<origin-path>/<file>
```

In the current proxy, this request does not match the Emby-specific redirect routes (`/Videos/...`, `/Audio/...`, `/Items/...`). It falls through to the catch-all proxy and is sent to Emby, which returns `404`. Server-side ffprobe then sees no media input, so StrmAssistant cannot extract or persist MediaInfo.

This patch adds a narrow pre-handler to the existing catch-all route. It matches only an HTTP(S) `strmPrefix` belonging to an enabled `enable302` task, reconstructs the URL in the same form stored in the `.strm` file, and reuses the existing direct-link resolver/cache. On failure or no match, the original Emby fallback is unchanged.

## Root cause

```text
bare STRM URL
  -> no existing OpenStrm route
  -> catch-all proxy
  -> Emby
  -> 404
  -> ffprobe has no streams/format
```

`enable302=true` currently affects Emby playback routes, but does not by itself make the generated bare URL a media endpoint.

## Implementation

- Add a pure `matchBareStrmRequest()` matcher.
- Require:
  - `enable302=true`;
  - an HTTP(S) `strmPrefix`;
  - matching request host;
  - request path below the configured prefix and task `originPath`;
  - longest/specific `originPath` wins.
- Attach the handler as a parent-scope `preHandler` in `catch-all.ts`. This avoids registering a second `/*` route, which conflicts with `@fastify/http-proxy`.
- Add `redirectBareStrm()` to reuse the existing resolver, safe `Location` handling, cache revision and UA-aware cache key.
- Return `false` on unresolved paths/errors so the original catch-all fallback remains intact.
- Support both `GET` and `HEAD`.
- No STRM regeneration, database schema change, Emby route change, or configuration migration is required.

The `.strm` URL itself remains the capability boundary. This route is intentionally limited to configured task prefixes; deployments should continue to protect the proxy port as they protect existing STRM URLs.

## Tests

Added unit coverage for:

- direct configured prefix matching;
- host/path/`enable302` isolation;
- longest `originPath` selection;
- a root URL prefix with no path component.

Added proxy integration coverage for:

- bare `GET` returning `302`;
- `HEAD` reusing the UA-aware link cache;
- paths outside `originPath` falling through to Emby;
- following the redirect to a test media endpoint with `Range: bytes=0-3`, receiving `206`, `Content-Range`, and actual bytes.

Validation performed on the changed worktree:

```text
pnpm lint                         PASS
backend/frontend typecheck       PASS
full backend test suite           515 passed, 0 failed
proxy integration tests           40 passed, 0 failed
Docker build                      PASS
built-image dist runtime test     302 -> 206 + Content-Range + bytes PASS
built-image health endpoint       HTTP 200 / healthy PASS
```

## Additional local validation with a real 115 file

A disposable test instance was started from a SQLite backup of the production config. At that stage, the production container and its bind mounts were never stopped or mounted into the test instance.

The selected real `.strm` was requested through the patched proxy with `Range: bytes=0-63`:

```text
proxy response: 302
final response: 206
content-type: application/octet-stream
content-length: 64
content-range: bytes 0-63/6419039802
media bytes: 64
```

The currently installed Emby ffprobe (`5.1-emby_2023_06_25`) then read the same test URL and returned:

```text
exit code: 0
streams: 7
format: present
format_name: matroska,webm
stderr HTTP error flags: none
```

The disposable container and copied config/data were removed after verification. At that point, the production OpenStrm container was still running the original image.

## Deployment smoke test after the isolated validation

After the isolated test passed, the same source tree was rebuilt as `openstrm:bare-strm-fix-d411260` and temporarily deployed with the existing production config/data mounts. The original container was stopped but preserved under a rollback name and the original image was retained under a rollback tag.

A real existing `.strm` was then requested through the deployed patched container:

```text
proxy response: 302
final response: 206
content-range: bytes 0-63/<redacted-total>
media bytes: 64
log marker: bare STRM redirect success
old Emby 404 marker: absent
health: HTTP 200 / Docker healthy
```

This deployment smoke test was manual runtime evidence only; it does not replace CI or the repository test suite. No STRM regeneration or schema migration was performed.

## Manual reproduction before this patch

1. Generate or select a `.strm` containing a configured OpenStrm proxy URL.
2. Request the URL with ordinary `GET` and `Range: bytes=0-63`.
3. Observe `404 Not Found` from the Emby fallback, with no `Location`, `Content-Range`, or media bytes.
4. Run the same URL through the Emby ffprobe binary and observe an empty probe result / no `streams` or `format`.

## Manual validation after deployment

Use one known `.strm` only. Do not regenerate the library initially.

```bash
curl -sS -D /tmp/headers \
  -H 'User-Agent: Lavf/...' \
  -H 'Range: bytes=0-63' \
  'http://<proxy-host>:<proxy-port>/<configured-path>/<file>' \
  -o /tmp/sample.bytes
```

Verify:

- the response is `302` or a valid media `200/206`;
- a `Location` exists when redirected;
- the final request returns media bytes;
- a range response contains `206` and `Content-Range` when supported;
- the same Emby ffprobe invocation reports non-empty `streams` and `format`;
- StrmAssistant `MediaInfoExtract` succeeds before checking `MediaInfoPersist`.

Redact signed URL query parameters, cookies, tokens, account names and private hostnames in issue reports.

## Scope / compatibility notes

- Existing `/Videos`, `/Audio`, `/Items`, `/Sync/JobItems` and `PlaybackInfo` routes are not changed.
- Unmatched requests and resolver failures retain the existing Emby fallback behavior.
- Local-path STRM tasks and non-HTTP prefixes are ignored by the new matcher.
- Tasks with `enable302=false` are ignored.
- The patch returns a redirect rather than proxying media bytes itself; the existing 115 resolver supplies the direct URL and the downstream server remains responsible for `Range` support.

## Follow-up question for maintainers

Would the project prefer this behavior to be controlled by a separate explicit setting (for example, `enableBareStrmRedirect`), or is `enable302` the intended capability flag for configured HTTP(S) STRM prefixes?
